### PR TITLE
Add config update action to structure viewer

### DIFF
--- a/file_handling.py
+++ b/file_handling.py
@@ -110,7 +110,7 @@ def update_all_structures_template(structures_dir):
         "structures": all_structures
     }
     template_path = os.path.join('structure templates', 'all_structures.json')
-    save_template(template, template_path)
+    save_template(template, template_path, all_structures)
 
 def get_content(file_path):
     with open(file_path, 'r') as file:

--- a/main_gui.py
+++ b/main_gui.py
@@ -172,7 +172,10 @@ class MainGUI(QMainWindow):
 
     def open_structure_database_viewer(self):
         database_dir = os.path.join(os.getcwd(), 'structure_database')
-        self.structure_database_viewer = StructureDatabaseViewer(database_dir, self)
+        config_path = os.path.join(os.getcwd(), 'config.txt')
+        self.structure_database_viewer = StructureDatabaseViewer(
+            database_dir, self, config_path
+        )
         self.structure_database_viewer.show()
 
     def select_output_directory(self):


### PR DESCRIPTION
## Summary
- add function in `file_handling.update_all_structures_template` to pass `all_structures`
- allow `StructureDatabaseViewer` to update structures from the config
- expose update capability through a new button in the viewer
- pass config path when viewer is opened

## Testing
- `python -m py_compile main_gui.py structure_database_viewer.py file_handling.py`