### PR TITLE
Switch results storage to SQLite

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -3,7 +3,6 @@ import logging
 import re
 import shutil
 import subprocess
-import json
 from ast import parse
 from concurrent.futures import ThreadPoolExecutor
 


### PR DESCRIPTION
## Summary
- store task results in a SQLite DB instead of many JSON files
- compute node iteration directly from the DB
- load node outputs by querying the DB
- remove unused json import in tasks

## Testing
- `python3 -m py_compile main_gui.py tasks.py`