### PR TITLE
Fix RWP task crash

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -711,7 +711,10 @@ class RWPTask(BaseTask):
         self.logger.info(f"Combined data: {combined_data}")
 
         # Screen data if needed
-        self.screen_data(combined_datatask_type="RWP")
+        # The screen_data method expects the parsed data and the task type
+        # as separate arguments. A typo here previously combined them into
+        # one invalid argument causing a crash when running the RWP task.
+        self.screen_data(combined_data, task_type="RWP")
 
         # Cleanup
         self.clear_input_output_files()


### PR DESCRIPTION
## Summary
- fix argument error in RWP task

## Testing
- `python -m py_compile tasks.py`