### PR TITLE
Fix parsing when structure section missing

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -640,7 +640,8 @@ class MainGUI(QMainWindow):
             node_id=node_id,
             parameters=parameters,
             data=required_data,
-            output_directory=self.output_directory
+            output_directory=self.output_directory,
+            db_conn=self.db_conn
         )
         task.run()
 


### PR DESCRIPTION
## Summary
- add database connection argument to BaseTask
- pull crystallite size and percentage weight from database if not found in output
- pass database connection from `MainGUI` when instantiating tasks

## Testing
- `python -m py_compile $(git ls-files '*.py')`